### PR TITLE
New interface to test Python Runnables

### DIFF
--- a/src/python/ensembl/hive/HiveRESTClient.py
+++ b/src/python/ensembl/hive/HiveRESTClient.py
@@ -91,8 +91,8 @@ class HiveRESTClient(eHive.BaseRunnable):
         Return response received.
         """
         with self._session_scope() as http:
-            self.response = http.request(method=self.param('method'),
-                                         url=self.param('endpoint'),
+            self.response = http.request(self.param_required('method'),
+                                         self.param_required('endpoint'),
                                          headers=self.param('headers'),
                                          files=self.param('files'),
                                          data=self.param('payload'),

--- a/src/python/ensembl/hive/HiveRESTClient.py
+++ b/src/python/ensembl/hive/HiveRESTClient.py
@@ -100,12 +100,6 @@ class HiveRESTClient(eHive.BaseRunnable):
                                          timeout=self.param('timeout'))
 
 
-
-    def run(self):
-        # should do something with results from fetch_input method
-        self.warning("You may do something with retrieved response {}".format(self.response.json()), is_error=False)
-
-
     def write_output(self):
         """
         Added code to process the response received from api call.

--- a/src/python/ensembl/hive/HiveRESTClient.py
+++ b/src/python/ensembl/hive/HiveRESTClient.py
@@ -91,12 +91,13 @@ class HiveRESTClient(eHive.BaseRunnable):
         Return response received.
         """
         with self._session_scope() as http:
-            self.response = http.request(self.param_required('method'),
+            response = http.request(self.param_required('method'),
                                          self.param_required('endpoint'),
                                          headers=self.param('headers'),
                                          files=self.param('files'),
                                          data=self.param('payload'),
                                          timeout=self.param('timeout'))
+            self.param('response', response)
 
 
     def write_output(self):
@@ -106,4 +107,4 @@ class HiveRESTClient(eHive.BaseRunnable):
         :param response:
         :return:
         """
-        self.dataflow({"rest_response": self.response.json()}, 1)
+        self.dataflow({"rest_response": self.param('response').json()}, 1)

--- a/src/python/ensembl/hive/HiveRESTClient.py
+++ b/src/python/ensembl/hive/HiveRESTClient.py
@@ -37,7 +37,6 @@ class HiveRESTClient(eHive.BaseRunnable):
         :return: dict
         """
         return {
-            'endpoint': 'http://localhost/api/endpoint',
             'payload': {},
             'headers': {'content-type': 'application/json; charset=utf8'},
             'files': [],

--- a/src/tests/hive/hive.in
+++ b/src/tests/hive/hive.in
@@ -1,2 +1,0 @@
-{"response": "OK"}
-{"response": "OK"}


### PR DESCRIPTION
In Ensembl/ensembl-hive#167 eHive is getting a mechanism to test runnables directly in Python.

I have made the changes to match the new interface. Please do not merge this until the eHive PR is merged, as the interface may slightly change.

I have also addressed other comments from #1