### PR TITLE
Include NCBI taxonomy ORM

### DIFF
--- a/src/python/ensembl/ncbi_taxonomy/__init__.py
+++ b/src/python/ensembl/ncbi_taxonomy/__init__.py
@@ -1,0 +1,14 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Taxonomy module"""

--- a/src/python/ensembl/ncbi_taxonomy/models.py
+++ b/src/python/ensembl/ncbi_taxonomy/models.py
@@ -1,0 +1,69 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    Index,
+    join,
+    Table,
+)
+from sqlalchemy.dialects.mysql import (
+    INTEGER,
+    TINYINT,
+    VARCHAR,
+    CHAR,
+)
+from sqlalchemy.orm import (
+    relationship,
+    column_property,
+)
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()
+metadata = Base.metadata
+
+
+class NCBITaxaNode(Base):
+    __tablename__ = "ncbi_taxa_node"
+
+    taxon_id = Column(INTEGER(10), primary_key=True)
+    parent_id = Column(INTEGER(10), nullable=False, index=True)
+    rank = Column(CHAR(32), nullable=False, index=True)
+    genbank_hidden_flag = Column(TINYINT(1), nullable=False, default=0)
+    left_index = Column(INTEGER(10), nullable=False, default=0, index=True)
+    right_index = Column(INTEGER(10), nullable=False, default=0, index=True)
+    root_id = Column(INTEGER(10), nullable=False, default=1)
+    children = relationship("NCBITaxaName")
+
+
+class NCBITaxaName(Base):
+    __tablename__ = "ncbi_taxa_name"
+
+    taxon_id = Column(INTEGER(10), ForeignKey("ncbi_taxa_node.taxon_id"), index=True, primary_key=True)
+    name = Column(VARCHAR(255), index=True, primary_key=True)
+    name_class = Column(VARCHAR(50), nullable=False, index=True)
+
+
+ncbi_taxa_name_table = NCBITaxaName.__table__
+ncbi_taxa_node_table = NCBITaxaNode.__table__
+
+name_node_join = join(ncbi_taxa_name_table, ncbi_taxa_node_table)
+
+
+class NCBITaxonomy(Base):
+    __table__ = name_node_join
+
+    taxon_id = column_property(ncbi_taxa_name_table.c.taxon_id, ncbi_taxa_node_table.c.taxon_id)
+


### PR DESCRIPTION
## Compara needs ncbi taxonomy

... I think a lot of the teams use ncbi taxonomy - so `ensembl-py` is the place to put it.
As we (EnsEMBL) move *away* from _*Perl*_ a need arises for Python alternatives - here I present the NCBI taxonomy ORM beginnings in `model` form.

Has been tested via: `from ensembl.ncbi_taxonomy.models import (NCBITaxaName, NCBITaxaNode, NCBITaxonomy)` in python shell - error free.