### PR TITLE
Allow re-use of UnitTestDB between pytest scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv~=0.19.2
 PyYAML~=6.0
 requests>=2.22.0
 sqlalchemy>=1.4.0
+SQLAlchemy-Utils~=0.37.0

--- a/src/python/ensembl/database/unittestdb.py
+++ b/src/python/ensembl/database/unittestdb.py
@@ -73,9 +73,7 @@ class UnitTestDB:
         # SQLite databases are created automatically if they do not exist
         if db_url.get_dialect().name != 'sqlite':
             # Connect to the server to create the database
-            if database_exists(db_url):
-                pass
-            else:
+            if not database_exists(db_url):
                 self._server = create_engine(url)
                 self._server.execute(text(f"CREATE DATABASE {db_url.database};"))
         try:

--- a/src/python/ensembl/database/unittestdb.py
+++ b/src/python/ensembl/database/unittestdb.py
@@ -38,6 +38,7 @@ from typing import Iterator, Union
 import sqlalchemy
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine.url import make_url
+from sqlalchemy_utils import database_exists
 
 from .dbconnection import DBConnection, Query, URL
 
@@ -72,17 +73,25 @@ class UnitTestDB:
         # SQLite databases are created automatically if they do not exist
         if db_url.get_dialect().name != 'sqlite':
             # Connect to the server to create the database
-            self._server = create_engine(url)
-            self._server.execute(text(f"CREATE DATABASE {db_url.database};"))
+            if database_exists(db_url):
+                pass
+            else:
+                self._server = create_engine(url)
+                self._server.execute(text(f"CREATE DATABASE {db_url.database};"))
         try:
             # Establish the connection to the database, load the schema and import the data
             self.dbc = DBConnection(db_url)
             with self.dbc.begin() as conn:
                 for query in self._parse_sql_file(dump_dir_path / 'table.sql'):
-                    conn.execute(query)
                     table = self._get_table_name(query)
+                    try:
+                        conn.execute(query)
+                    except sqlalchemy.exc.OperationalError:
+                        conn.execute(f"DROP TABLE IF EXISTS {table}")
+                        conn.execute(query)
                     filepath = dump_dir_path / f"{table}.txt"
                     if table and filepath.exists():
+                        conn.execute(f"TRUNCATE TABLE {table}")
                         self._load_data(conn, table, filepath)
         except:
             # Make sure the database is deleted before raising the exception


### PR DESCRIPTION
## Description
While writing pytests in `ensembl-compara` Travis suddenly started to fail on a whole group of tests that used to pass - it turned out this was because the `UnitTestDB` was trying to re-create the db (regardless of `pytest.fixture` `scope`).

Did consider providing support for reusing the database as is - without dropping/truncating/recreating between test scripts - but decided this additional functionality is not that useful, in a sense it is better to make this the default behaviour since test solutions can be independent of each other this way, starting with a fresh database in case a future test alters a test db.

## Changes
- Altered `unittestdb.py`  to check for existing database instance and only create if not in existence.
- Try to create tables using the `table.sql` queries - but if  `OperationalError` exception is raised the existing table is dropped first and then recreated.
- `TRUNCATE` all the table data before each data load.

## Tests

Tested locally with `pytest` on `ensembl-compara` repository:
```
pytest src/python/tests/
```
All tests passed

