### PR TITLE
Data-related fix with multiple species ncbi taxonomy

### DIFF
--- a/src/python/ensembl/ncbi_taxonomy/api/utils.py
+++ b/src/python/ensembl/ncbi_taxonomy/api/utils.py
@@ -62,7 +62,7 @@ class Taxonomy():
 
     @classmethod
     def fetch_taxon_by_species_name(cls, session: Session, name: str) -> NCBITaxonomy:
-        """Returns taxonomy object matching ``name``
+        """Returns first taxonomy object matching ``name``
 
         Args:
             name: Scientific ncbi_taxa_name.name in database

--- a/src/python/ensembl/ncbi_taxonomy/api/utils.py
+++ b/src/python/ensembl/ncbi_taxonomy/api/utils.py
@@ -68,16 +68,17 @@ class Taxonomy():
             name: Scientific ncbi_taxa_name.name in database
 
         Raises:
-            sqlalchemy.orm.exc.NoResultFound: if ``taxon_id`` does not exist or
-            returns multiple results
+            sqlalchemy.orm.exc.NoResultFound: if ``taxon_id`` does not exist
         """
-        name.replace("_", " ")
-        return (
+        q = (
             session.query(NCBITaxonomy)
-            .filter(NCBITaxonomy.name.like(name))
+            .filter(NCBITaxonomy.name == (name.replace("_", " ")))
             .filter(NCBITaxonomy.name_class == "scientific name")
-            .one()
+            .first()
         )
+        if not q:
+            raise NoResultFound()
+        return q
 
     @classmethod
     def parent(cls, session: Session, taxon_id: int) -> NCBITaxonomy:


### PR DESCRIPTION
## Description
For commonly studied species, and species with multiple entries in the `ncbi_taxonomy` database, the `ncbi_taxa_name.name` can be shared as a `like` pattern for many species, so this needs to be a proper `==` match rather than a `like` match on the query returned.