### PR TITLE
Widen name attribute of NCBITaxaName class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - mysql
 
 python:
-  - "3.7"
+  - "3.7.11"
 
 env:
   - TESTENV=test

--- a/src/python/ensembl/ncbi_taxonomy/models.py
+++ b/src/python/ensembl/ncbi_taxonomy/models.py
@@ -52,7 +52,7 @@ class NCBITaxaName(Base):
     __tablename__ = "ncbi_taxa_name"
 
     taxon_id = Column(INTEGER(10), ForeignKey("ncbi_taxa_node.taxon_id"), index=True, primary_key=True)
-    name = Column(VARCHAR(255), index=True, primary_key=True)
+    name = Column(VARCHAR(500), index=True, primary_key=True)
     name_class = Column(VARCHAR(50), nullable=False, index=True)
 
 

--- a/src/tests/databases/ncbi_db/table.sql
+++ b/src/tests/databases/ncbi_db/table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE `ncbi_taxa_name` (
   `taxon_id` int(10) unsigned NOT NULL,
-  `name` varchar(255) NOT NULL,
+  `name` varchar(500) NOT NULL,
   `name_class` varchar(50) NOT NULL,
   KEY `taxon_id` (`taxon_id`),
   KEY `name` (`name`),


### PR DESCRIPTION
## Description

A [recent change to the ensembl-taxonomy schema](https://github.com/Ensembl/ensembl-taxonomy/pull/20/files#diff-166a1642d57c0370697b6b03aeaee766322d96001a14683cd5852580f7f49a3a) widens the `name` column of the `ncbi_taxa_name` table to 500 characters.

If accepted, this PR would make the relevant parts of `ensembl-py` code consistent with the updated `ensembl-taxonomy` schema.

## Changes

- The `name` attribute of the `ensembl.ncbi_taxonomy.models.NCBITaxaName` class is changed to represent a `VARCHAR(500)` column.
- In the `ncbi_db` test database schema (`src/tests/databases/ncbi_db/table.sql`), the `name` column of the `ncbi_taxa_name` table is also changed to `varchar(500)`.

## Tests

Ran `test_ncbi_taxonomy.py` locally.