### PR TITLE
Change to "compatible" version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pytest-dependency==0.5.1
 python-dotenv~=0.19.2
 PyYAML~=6.0
 requests>=2.22.0
-sqlalchemy>=1.4.0
+sqlalchemy~=1.4.0
 SQLAlchemy-Utils~=0.37.0


### PR DESCRIPTION
We are not ready to use SQLAlchemy 2.x yet, at least in production, and intensively use 1.4.x. It appears that our pipelines fetch 2.0 (ensembl-metadata-api)