### PR TITLE
Update dependency with eHive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git@main",
+    "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git",
     "mysqlclient >= 1.4.6",
     "pytest >= 5.2.1",
     "pytest-dependency == 0.5.1",


### PR DESCRIPTION
Dependencies over GitHub repositories should not be based on "development" branches.