### PR TITLE
Bugfixes/keep data server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 name = "ensembl-py"
 description = "Ensembl Python Base Library"
 requires-python = ">= 3.8"
-version = "0.1"
+version = "1.1.0"
 readme = "README.md"
 authors = [
     {name = "Ensembl", email = "dev@ensembl.org"},

--- a/src/python/ensembl/database/unittestdb.py
+++ b/src/python/ensembl/database/unittestdb.py
@@ -91,7 +91,10 @@ class UnitTestDB:
                         conn.execute(query)
                     filepath = dump_dir_path / f"{table}.txt"
                     if table and filepath.exists():
-                        conn.execute(f"TRUNCATE TABLE {table}")
+                        if db_url.get_dialect().name != 'sqlite':
+                            conn.execute(f"TRUNCATE TABLE {table}")
+                        else:
+                            conn.execute(f"DELETE FROM {table}")
                         self._load_data(conn, table, filepath)
         except:
             # Make sure the database is deleted before raising the exception

--- a/src/python/ensembl/database/unittestdb.py
+++ b/src/python/ensembl/database/unittestdb.py
@@ -73,9 +73,11 @@ class UnitTestDB:
         # SQLite databases are created automatically if they do not exist
         if db_url.get_dialect().name != 'sqlite':
             # Connect to the server to create the database
-            if not database_exists(db_url):
-                self._server = create_engine(url)
-                self._server.execute(text(f"CREATE DATABASE {db_url.database};"))
+            self._server = create_engine(url)
+            # for innodb schema, unitary drop table doesn't work, if data present
+            # so whatever it is, drop before create
+            self._server.execute(text(f"DROP DATABASE IF EXISTS {db_url.database};"))
+            self._server.execute(text(f"CREATE DATABASE {db_url.database};"))
         try:
             # Establish the connection to the database, load the schema and import the data
             self.dbc = DBConnection(db_url)

--- a/src/python/ensembl/plugins/pytest_unittest.py
+++ b/src/python/ensembl/plugins/pytest_unittest.py
@@ -44,7 +44,8 @@ def pytest_addoption(parser: Parser) -> None:
     """
     # Add the Ensembl unitary test parameters to pytest parser
     group = parser.getgroup("ensembl unit testing")
-    group.addoption('--server', action='store', metavar='URL', dest='server', required=True,
+    group.addoption('--server', action='store', metavar='URL', dest='server', required=False,
+                    default=os.getenv('DB_HOST', 'mysql://ensembl@localhost:3306'),
                     help="URL to the server where to create the test database(s).")
     group.addoption('--keep-data', action='store_true', dest='keep_data',
                     help="Do not remove test databases/temporary directories. Default: False")

--- a/src/python/ensembl/plugins/pytest_unittest.py
+++ b/src/python/ensembl/plugins/pytest_unittest.py
@@ -45,7 +45,7 @@ def pytest_addoption(parser: Parser) -> None:
     # Add the Ensembl unitary test parameters to pytest parser
     group = parser.getgroup("ensembl unit testing")
     group.addoption('--server', action='store', metavar='URL', dest='server', required=False,
-                    default=os.getenv('DB_HOST', 'mysql://ensembl@localhost:3306'),
+                    default=os.getenv('DB_HOST', 'sqlite:////'),
                     help="URL to the server where to create the test database(s).")
     group.addoption('--keep-data', action='store_true', dest='keep_data',
                     help="Do not remove test databases/temporary directories. Default: False")

--- a/src/python/ensembl/plugins/pytest_unittest.py
+++ b/src/python/ensembl/plugins/pytest_unittest.py
@@ -44,8 +44,7 @@ def pytest_addoption(parser: Parser) -> None:
     """
     # Add the Ensembl unitary test parameters to pytest parser
     group = parser.getgroup("ensembl unit testing")
-    group.addoption('--server', action='store', metavar='URL', dest='server', required=False,
-                    default=os.getenv('DB_HOST', 'mysql://ensembl@localhost:3306'),
+    group.addoption('--server', action='store', metavar='URL', dest='server', required=True,
                     help="URL to the server where to create the test database(s).")
     group.addoption('--keep-data', action='store_true', dest='keep_data',
                     help="Do not remove test databases/temporary directories. Default: False")


### PR DESCRIPTION
Aim to use a `env` var if available not to have to pass the `--server` param.
fix the use case with `keep-data` where the drop table can't work with an innodb schema. 