### PR TITLE
Exclude tests folder for package building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ version = {attr = "ensembl.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["src/python"]
+exclude = ["tests*"]
 
 # For additional information on `setuptools` configuration see:
 #    https://setuptools.pypa.io/en/latest/userguide/quickstart.html


### PR DESCRIPTION
If not, `import tests` will be available when installing this repository, which is not what we want (or even desirable).