### PR TITLE
Add logging arguments method to ease usage of logging system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 name = "ensembl-py"
 description = "Ensembl Python Base Library"
 requires-python = ">= 3.8"
-version = "1.1.1"
+version = "1.2.1"
 readme = "README.md"
 authors = [
     {name = "Ensembl", email = "dev@ensembl.org"},

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -37,6 +37,7 @@ class ArgumentParser(argparse.ArgumentParser):
         super().__init__(*args, **kwargs)
         self.formatter_class = argparse.ArgumentDefaultsHelpFormatter
         self.__server_groups = []
+        self.__set_logging = False
 
     def _validate_src_path(self, src_path: os.PathLike) -> Path:
         """Returns the path if exists and it is readable, raises an error through the parser otherwise.
@@ -160,11 +161,57 @@ class ArgumentParser(argparse.ArgumentParser):
             )
         self.__server_groups.append(prefix)
 
+    def add_log_arguments(self) -> None:
+        """Adds the usual set of arguments required to set (and initialise) a logging system.
+
+        The current set includes "--log_file" and a mutually exclusive group for the logging level:
+        "--log", "--verbose" or "--debug". The logging level is used at parsing time to initialise the
+        basic configuration of the root logger.
+
+        """
+        group = self.add_argument_group("logging arguments")
+        group.add_argument(
+            "--log_file",
+            type=lambda x: self._validate_dst_path(x, exists_ok=True),
+            metavar="PATH",
+            help="Log file path",
+        )
+        # Add 3 mutually exclusive options to set the logging level
+        subgroup = group.add_mutually_exclusive_group()
+        subgroup.add_argument(
+            "--log",
+            metavar="LEVEL",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+            # NOTE: in 3.11 the choices value can be changed to: logging.getLevelNamesMapping().keys()
+            type=str.upper,
+            default=logging.getLevelName(logging.root.level),
+            dest="log_level",
+            help="Level or severity of the events to track: %(choices)s",
+        )
+        subgroup.add_argument(
+            "-v",
+            "--verbose",
+            action="store_const",
+            const="INFO",
+            default=argparse.SUPPRESS,
+            dest="log_level",
+            help="Verbose mode",
+        )
+        subgroup.add_argument(
+            "--debug",
+            action="store_const",
+            const="DEBUG",
+            default=argparse.SUPPRESS,
+            dest="log_level",
+            help="Debugging mode",
+        )
+        self.__set_logging = True
+
     def parse_args(self, *args, **kwargs) -> argparse.Namespace:
         """Extends the parent function by adding a new URL argument for every server group added.
 
         The type of this new argument will be :class:`sqlalchemy.engine.URL`. It also logs all the parsed
-        arguments for debugging purposes.
+        arguments for debugging purposes when logging arguments have been added.
 
         """
         args = super().parse_args(*args, **kwargs)
@@ -182,8 +229,14 @@ class ArgumentParser(argparse.ArgumentParser):
                 getattr(args, f"{prefix}database", None),
             )
             setattr(args, f"{prefix}url", server_url)
-        # Log the parsed arguments for debugging purposes
-        logging.debug(f"{self.prog} called with the following arguments:")
-        for x in sorted(vars(args)):
-            logging.debug("  --%s %s", x, getattr(args, x))
+        # Initialise basic logging system with the selected logging level if the arguments have been added
+        if self.__set_logging:
+            if args.log_file:
+                logging.basicConfig(level=args.log_level, filename=args.log_file)
+            else:
+                logging.basicConfig(level=args.log_level)
+            # Log the parsed arguments for debugging purposes
+            logging.debug(f"{self.prog} called with the following arguments:")
+            for x in sorted(vars(args)):
+                logging.debug("  --%s %s", x, getattr(args, x))
         return args

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -132,7 +132,7 @@ class ArgumentParser(argparse.ArgumentParser):
         """
         group = self.add_argument_group(f"{prefix}server connection arguments", description=help)
         group.add_argument(
-            f"--{prefix}host", required=True, default=argparse.SUPPRESS, metavar="HOST", help="Host name"
+            f"--{prefix}host", required=True, default=argparse.SUPPRESS, metavar="HOST", help="host name"
         )
         group.add_argument(
             f"--{prefix}port",
@@ -140,19 +140,19 @@ class ArgumentParser(argparse.ArgumentParser):
             type=int,
             default=argparse.SUPPRESS,
             metavar="PORT",
-            help="Port number",
+            help="port number",
         )
         group.add_argument(
-            f"--{prefix}user", required=True, default=argparse.SUPPRESS, metavar="USER", help="User name"
+            f"--{prefix}user", required=True, default=argparse.SUPPRESS, metavar="USER", help="user name"
         )
-        group.add_argument(f"--{prefix}password", metavar="PWD", help="Host password")
+        group.add_argument(f"--{prefix}password", metavar="PWD", help="host password")
         if include_database:
             group.add_argument(
                 f"--{prefix}database",
                 required=True,
                 default=argparse.SUPPRESS,
                 metavar="NAME",
-                help="Database name",
+                help="database name",
             )
         self.__server_groups.append(prefix)
 
@@ -181,7 +181,7 @@ class ArgumentParser(argparse.ArgumentParser):
             const="INFO",
             default=argparse.SUPPRESS,
             dest="log_level",
-            help="Verbose mode, i.e. 'INFO' log level",
+            help="verbose mode, i.e. 'INFO' log level",
         )
         subgroup.add_argument(
             "--debug",
@@ -189,7 +189,7 @@ class ArgumentParser(argparse.ArgumentParser):
             const="DEBUG",
             default=argparse.SUPPRESS,
             dest="log_level",
-            help="Debugging mode, i.e. 'DEBUG' log level",
+            help="debugging mode, i.e. 'DEBUG' log level",
         )
         subgroup.add_argument(
             "--log",
@@ -198,7 +198,7 @@ class ArgumentParser(argparse.ArgumentParser):
             type=str.upper,
             default="WARNING",
             dest="log_level",
-            help="Level or severity of the events to track: %(choices)s",
+            help="level of the events to track: %(choices)s",
         )
         if add_log_file:
             # Add log file-related arguments
@@ -206,7 +206,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 "--log_file",
                 type=lambda x: self._validate_dst_path(x, exists_ok=True),
                 metavar="PATH",
-                help="Log file path",
+                help="log file path",
             )
             group.add_argument(
                 "--log_file_level",
@@ -214,7 +214,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 choices=log_levels,
                 type=str.upper,
                 default="DEBUG",
-                help="Level or severity of the events to track in the log file: %(choices)s",
+                help="level of the events to track in the log file: %(choices)s",
             )
 
     def parse_args(self, *args, **kwargs) -> argparse.Namespace:

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -83,8 +83,8 @@ class ArgumentParser(argparse.ArgumentParser):
         arguments with "required=True".
 
         """
-        if kwargs.get("required", False) and "default" not in kwargs:
-            kwargs["default"] = argparse.SUPPRESS
+        if kwargs.get("required", False):
+            kwargs.setdefault("default", argparse.SUPPRESS)
         super().add_argument(*args, **kwargs)
 
     def add_argument_src_path(self, *args, **kwargs) -> None:
@@ -93,10 +93,9 @@ class ArgumentParser(argparse.ArgumentParser):
         If "metavar" is not defined it is added with "PATH" as value to improve help text readability.
 
         """
-        if "metavar" not in kwargs:
-            kwargs["metavar"] = "PATH"
-        kwargs.pop("type", None)
-        self.add_argument(*args, **kwargs, type=lambda x: self._validate_src_path(x))
+        kwargs.setdefault("metavar", "PATH")
+        kwargs["type"] = lambda x: self._validate_src_path(x)
+        self.add_argument(*args, **kwargs)
 
     def add_argument_dst_path(self, *args, exists_ok: bool = True, **kwargs) -> None:
         """Adds :class:`pathlib.Path` argument, checking if it is writable at parsing time.
@@ -107,10 +106,9 @@ class ArgumentParser(argparse.ArgumentParser):
             exists_ok: Do not raise an error if the destination path already exists.
 
         """
-        if "metavar" not in kwargs:
-            kwargs["metavar"] = "PATH"
-        kwargs.pop("type", None)
-        self.add_argument(*args, **kwargs, type=lambda x: self._validate_dst_path(x, exists_ok))
+        kwargs.setdefault("metavar", "PATH")
+        kwargs["type"] = lambda x: self._validate_dst_path(x, exists_ok)
+        self.add_argument(*args, **kwargs)
 
     def add_argument_url(self, *args, **kwargs) -> None:
         """Adds :class:`sqlalchemy.engine.URL` argument.
@@ -118,10 +116,9 @@ class ArgumentParser(argparse.ArgumentParser):
         If "metavar" is not defined it is added with "URI" as value to improve help text readability.
 
         """
-        if "metavar" not in kwargs:
-            kwargs["metavar"] = "URI"
-        kwargs.pop("type", None)
-        self.add_argument(*args, **kwargs, type=lambda x: make_url(x))
+        kwargs.setdefault("metavar", "URI")
+        kwargs["type"] = lambda x: make_url(x)
+        self.add_argument(*args, **kwargs)
 
     def add_server_arguments(self, prefix: str = "", include_database: bool = False, help: str = "") -> None:
         """Adds the usual set of arguments needed to connect to a server.

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -164,10 +164,10 @@ class ArgumentParser(argparse.ArgumentParser):
         )
         subgroup.add_argument(
             "--log",
-            metavar="LEVEL",
             choices=log_levels,
             type=str.upper,
             default="WARNING",
+            metavar="LEVEL",
             dest="log_level",
             help="level of the events to track: %(choices)s",
         )
@@ -177,14 +177,15 @@ class ArgumentParser(argparse.ArgumentParser):
                 "--log_file",
                 type=lambda x: self._validate_dst_path(x, exists_ok=True),
                 metavar="PATH",
+                default=None,
                 help="log file path",
             )
             group.add_argument(
                 "--log_file_level",
-                metavar="LEVEL",
                 choices=log_levels,
                 type=str.upper,
                 default="DEBUG",
+                metavar="LEVEL",
                 help="level of the events to track in the log file: %(choices)s",
             )
 

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -53,7 +53,6 @@ class ArgumentParser(argparse.ArgumentParser):
             self.error(f"'{src_path}' not readable")
         return src_path
 
-
     def _validate_dst_path(self, dst_path: os.PathLike, exists_ok: bool) -> Path:
         """Returns the path if it is writable, raises an error through the parser otherwise.
 

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -34,6 +34,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args, **kwargs) -> None:
         """Extends the base class to include the information about default argument values by default."""
+        kwargs["argument_default"] = argparse.SUPPRESS
         super().__init__(*args, **kwargs)
         self.formatter_class = argparse.ArgumentDefaultsHelpFormatter
         self.__server_groups = []
@@ -73,17 +74,6 @@ class ArgumentParser(argparse.ArgumentParser):
             if parent_path.exists() and not os.access(parent_path, os.W_OK):
                 self.error(f"'{dst_path}' is not writable")
         return dst_path
-
-    def add_argument(self, *args, **kwargs) -> None:
-        """Extends the parent function by excluding the default value in the help text when not provided.
-
-        Only applied to required arguments without a default value, i.e. positional arguments or optional
-        arguments with "required=True".
-
-        """
-        if kwargs.get("required", False):
-            kwargs.setdefault("default", argparse.SUPPRESS)
-        super().add_argument(*args, **kwargs)
 
     def add_argument_src_path(self, *args, **kwargs) -> None:
         """Adds :class:`pathlib.Path` argument, checking if it exists and it is readable at parsing time.
@@ -131,29 +121,12 @@ class ArgumentParser(argparse.ArgumentParser):
 
         """
         group = self.add_argument_group(f"{prefix}server connection arguments", description=help)
-        group.add_argument(
-            f"--{prefix}host", required=True, default=argparse.SUPPRESS, metavar="HOST", help="host name"
-        )
-        group.add_argument(
-            f"--{prefix}port",
-            required=True,
-            type=int,
-            default=argparse.SUPPRESS,
-            metavar="PORT",
-            help="port number",
-        )
-        group.add_argument(
-            f"--{prefix}user", required=True, default=argparse.SUPPRESS, metavar="USER", help="user name"
-        )
+        group.add_argument(f"--{prefix}host", required=True, metavar="HOST", help="host name")
+        group.add_argument(f"--{prefix}port", required=True, type=int, metavar="PORT", help="port number")
+        group.add_argument(f"--{prefix}user", required=True, metavar="USER", help="user name")
         group.add_argument(f"--{prefix}password", metavar="PWD", help="host password")
         if include_database:
-            group.add_argument(
-                f"--{prefix}database",
-                required=True,
-                default=argparse.SUPPRESS,
-                metavar="NAME",
-                help="database name",
-            )
+            group.add_argument(f"--{prefix}database", required=True, metavar="NAME", help="database name")
         self.__server_groups.append(prefix)
 
     def add_log_arguments(self, add_log_file: bool = False) -> None:
@@ -179,7 +152,6 @@ class ArgumentParser(argparse.ArgumentParser):
             "--verbose",
             action="store_const",
             const="INFO",
-            default=argparse.SUPPRESS,
             dest="log_level",
             help="verbose mode, i.e. 'INFO' log level",
         )
@@ -187,7 +159,6 @@ class ArgumentParser(argparse.ArgumentParser):
             "--debug",
             action="store_const",
             const="DEBUG",
-            default=argparse.SUPPRESS,
             dest="log_level",
             help="debugging mode, i.e. 'DEBUG' log level",
         )

--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -34,7 +34,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args, **kwargs) -> None:
         """Extends the base class to include the information about default argument values by default."""
-        kwargs["argument_default"] = argparse.SUPPRESS
+        kwargs.setdefault("argument_default", argparse.SUPPRESS)
         super().__init__(*args, **kwargs)
         self.formatter_class = argparse.ArgumentDefaultsHelpFormatter
         self.__server_groups = []

--- a/src/python/ensembl/utils/logging.py
+++ b/src/python/ensembl/utils/logging.py
@@ -12,7 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Easy initialisation functionality to set an event logging system."""
+"""Easy initialisation functionality to set an event logging system.
+
+Example:
+    >>> import logging, pathlib
+    >>> from ensembl.utils.logging import init_logging
+    >>> logfile = pathlib.Path("test.log")
+    >>> init_logging("INFO", logfile, "DEBUG")
+    >>> logging.info("This message is written in both stderr and the log file")
+    >>> logging.debug("This message is only written in the log file")
+
+"""
 
 __all__ = ["LogLevel", "init_logging"]
 

--- a/src/python/ensembl/utils/logging.py
+++ b/src/python/ensembl/utils/logging.py
@@ -1,0 +1,62 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Easy initialisation functionality to set an event logging system."""
+
+__all__ = ["LogLevel", "init_logging"]
+
+import logging
+from pathlib import Path
+from typing import Optional, Union
+
+
+LogLevel = Union[int, str]
+
+
+def init_logging(
+    log_level: LogLevel = "WARNING",
+    log_file: Optional[Path] = None,
+    log_file_level: LogLevel = "DEBUG",
+    msg_format: str = "%(asctime)s\t%(levelname)s\t%(message)s",
+    date_format: str = r"%Y-%m-%d_%H:%M:%S"
+) -> None:
+    """Initialises the logging system.
+
+    By default, all the log messages corresponding to `log_level` (and) above will be printed in the
+    standard error. If `log_file` is provided, all messages of `log_file_level` level (and above) will
+    be written into the provided file.
+
+    Args:
+        log_level: Minimum logging level for the standard error.
+        log_file: Logging file where to write debug (and above) logging messages.
+        log_file_level: Minimum logging level for the logging file.
+        msg_format: A format string for the logged output as a whole. More information:
+            https://docs.python.org/3/library/logging.html#logrecord-attributes
+        date_format: A format string for the date/time portion of the logged output. More information:
+            https://docs.python.org/3/library/logging.html#logging.Formatter.formatTime
+
+    """
+    # Configure the basic logging system, setting the root logger to the minimum log level available
+    # to avoid filtering messages in any handler due to "parent delegation". Also close and remove any
+    # existing handlers before setting this configuration.
+    logging.basicConfig(format=msg_format, datefmt=date_format, level="DEBUG", force=True)
+    # Set the correct log level of the new StreamHandler (by default it is set to NOTSET)
+    logging.root.handlers[0].setLevel(log_level)
+    if log_file:
+        # Create the log file handler and add it to the root logger
+        formatter = logging.Formatter(msg_format, datefmt=date_format)
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(log_file_level)
+        file_handler.setFormatter(formatter)
+        logging.root.addHandler(file_handler)


### PR DESCRIPTION
I have also taken the liberty to do some minor code simplification updates as well as corrected repository's version.

Example of how this addition will look like with all the logging arguments:
```
usage: assembly_download [-h] [--download_dir PATH] [-v | --debug | --log LEVEL] [--log_file PATH] [--log_file_level LEVEL] accession

Download an assembly data files from INSDC or RefSeq.

positional arguments:
  accession             genome assembly accession

optional arguments:
  -h, --help            show this help message and exit
  --download_dir PATH   folder where the data will be downloaded (default: .)

logging arguments:
  -v, --verbose         verbose mode, i.e. 'INFO' log level
  --debug               debugging mode, i.e. 'DEBUG' log level
  --log LEVEL           level of the events to track: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: WARNING)
  --log_file PATH       log file path (default: None)
  --log_file_level LEVEL
                        level of the events to track in the log file: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: DEBUG)
````