### PR TITLE
Added engine_extra params to init DBConnection

### DIFF
--- a/src/python/ensembl/database/dbconnection.py
+++ b/src/python/ensembl/database/dbconnection.py
@@ -52,10 +52,8 @@ class DBConnection:
         url: URL to the database, e.g. ``mysql://user:passwd@host:port/my_db``\.
 
     """
-    def __init__(self, url: URL, engine_extras: dict = None) -> None:
-        if not engine_extras:
-            engine_extras = {}
-        self._engine = create_engine(url, **engine_extras)
+    def __init__(self, url: URL, **kwargs) -> None:
+        self._engine = create_engine(url, **kwargs)
         self.load_metadata()
 
     def __repr__(self) -> str:

--- a/src/python/ensembl/database/dbconnection.py
+++ b/src/python/ensembl/database/dbconnection.py
@@ -52,8 +52,10 @@ class DBConnection:
         url: URL to the database, e.g. ``mysql://user:passwd@host:port/my_db``\.
 
     """
-    def __init__(self, url: URL) -> None:
-        self._engine = create_engine(url)
+    def __init__(self, url: URL, engine_extras: dict = None) -> None:
+        if not engine_extras:
+            engine_extras = {}
+        self._engine = create_engine(url, **engine_extras)
         self.load_metadata()
 
     def __repr__(self) -> str:


### PR DESCRIPTION
@JAlvarezJarreta  No test needed as per your recommendation. 
I quickly tested with sample code though:

```
db = DBConnection('mysql://ensprod:ensembl@localhost:3306/ensembl_genome_metadata', pool_size=50, pool_recycle=100)
print(db._engine.pool.status())
```

Output:
```
Pool size: 50  Connections in pool: 1 Current Overflow: -49 Current Checked out connections: 0
```

