### PR TITLE
Explicit default log_level for the group

### DIFF
--- a/src/python/ensembl/utils/argparse.py
+++ b/src/python/ensembl/utils/argparse.py
@@ -181,6 +181,7 @@ class ArgumentParser(argparse.ArgumentParser):
             dest="log_level",
             help="level of the events to track: %(choices)s",
         )
+        subgroup.set_defaults(log_level="WARNING")
         if add_log_file:
             # Add log file-related arguments
             group.add_argument(


### PR DESCRIPTION
Currently using the add_log_arguments() do not set the `args.log_level` if none of the `--verbose`, `--debug` or `--log_level` are called, and so the subsequent `setLevel()` in `init_logging()`.

This fix sets the default `log_level` for the parser subgroup.