### PR TITLE
Restrict mysqlclient version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 dependencies = [
     "ensembl-hive @ git+https://github.com/Ensembl/ensembl-hive.git",
-    "mysqlclient >= 1.4.6",
+    "mysqlclient >= 1.4.6, < 2.2.0",
     "pytest >= 5.2.1",
     "pytest-dependency == 0.5.1",
     "python-dotenv ~= 0.19.2",


### PR DESCRIPTION
The latest version (2.2.0) triggers an issue with `pkg-config` when doing `pip install`. The version before that (2.1.1) works just fine.