### PR TITLE
Fix escape char

### DIFF
--- a/src/python/ensembl/database/dbconnection.py
+++ b/src/python/ensembl/database/dbconnection.py
@@ -49,7 +49,7 @@ class DBConnection:
     """Database connection handler, providing also the database's schema and properties.
 
     Args:
-        url: URL to the database, e.g. ``mysql://user:passwd@host:port/my_db``\.
+        url: URL to the database, e.g. ``mysql://user:passwd@host:port/my_db``.
 
     """
     def __init__(self, url: URL, **kwargs) -> None:


### PR DESCRIPTION
This escape causes a warning:
```
DeprecationWarning: invalid escape sequence \.
    """Database connection handler, providing also the database's schema and properties.
```
