### PR TITLE
Remove tmp_dir fixture as pytest offers tmp_path since v6.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 name = "ensembl-py"
 description = "Ensembl Python Base Library"
 requires-python = ">= 3.8"
-version = "1.2.4"
+version = "1.3.0"
 readme = "README.md"
 authors = [
     {name = "Ensembl", email = "dev@ensembl.org"},

--- a/src/python/ensembl/plugins/pytest_unittest.py
+++ b/src/python/ensembl/plugins/pytest_unittest.py
@@ -158,19 +158,3 @@ def multi_dbs(request: FixtureRequest, db_factory: Callable) -> Dict:
         key = name if name else src.name
         databases[key] = db_factory(src, name)
     return databases
-
-
-@pytest.fixture(scope='session')
-def tmp_dir(request: FixtureRequest, tmp_path_factory: TempPathFactory) -> Generator:
-    """Yields a :class:`Path` object pointing to a newly created temporary directory.
-
-    Args:
-        request: Access to the requesting test context.
-        tmp_path_factory: Session-scoped fixture that creates arbitrary temporary directories.
-
-    """
-    tmpdir = tmp_path_factory.mktemp(f"test_{request.node.name}")
-    yield tmpdir
-    # Delete the temporary directory unless the user has requested to keep it
-    if not request.config.getoption("keep_data"):
-        shutil.rmtree(tmpdir)


### PR DESCRIPTION
As a note, `tmp_path` is a function-scoped fixture, so if someone needs a session-scoped one, they will need to use `tmp_path_factory` instead (which is what is recommended in the documentation).