### PR TITLE
Require DIND runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ workflow:
 
 default:
   tags:
-    - docker
+    - dind
 
 variables:
   PYTHON_IMAGE: python:3.9


### PR DESCRIPTION
For `mysql` dockers to work, runner must have DIND.