### PR TITLE
Grab all submodules, not only __init__.py

### DIFF
--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -14,6 +14,7 @@
 """Generate the code reference pages for mkdocs."""
 
 from pathlib import Path
+import re
 
 import mkdocs_gen_files
 
@@ -22,21 +23,27 @@ nav = mkdocs_gen_files.Nav()
 
 root = Path("src/python/ensembl")
 num_parents = len(root.parents) - 1
-for path in sorted(root.rglob("__init__.py")):
+for py_path in sorted(root.rglob("*.py")):
     # Get the relative module path
-    module_path = path.relative_to(root).parent
+    module_path = py_path.relative_to(root)
     doc_path = module_path.with_suffix(".md")
     full_doc_path = Path("reference", doc_path)
-    # Drop all the parents of the namespace and "__init__.py" file from the path components
-    parts = path.parts[num_parents:-1]
+    # Drop all the parents of the namespace from the path components
+    parts = py_path.parts[num_parents:]
+    if parts[-1] == "__init__.py":
+        # Drop "__init__.py" file from the path components as well
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
     # Add markdown file path with its index tree
     nav[parts] = doc_path.as_posix()
     # Populate the markdown file with the doc stub of this Python module
     with mkdocs_gen_files.open(full_doc_path, "a") as fd:
         identifier = ".".join(parts)
+        identifier = re.sub(r"\.py$", "", identifier)
         fd.write(f"::: {identifier}\n")
     # Correct the path
-    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / py_path)
 
-with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+with mkdocs_gen_files.open("reference/summary.md", "w") as nav_file:
     nav_file.writelines(nav.build_literate_nav())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ plugins:
      scripts:
      - docs/gen_ref_pages.py
 - literate-nav:
-    nav_file: SUMMARY.md
+    nav_file: summary.md
 - section-index
 - mkdocstrings:
     enabled: !ENV [ENABLE_MKDOCSTRINGS, true]


### PR DESCRIPTION
Most repositories will not need this trick, but due to the nature of this repository, not all modules have a `__init__.py` file in them.