### PR TITLE
Require type hints in all methods and functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue.svg)](https://github.com/Ensembl/ensembl-py/blob/main/LICENSE)
 [![Coverage](https://ensembl.github.io/ensembl-py/coverage/coverage-badge.svg)](https://ensembl.github.io/ensembl-py/coverage)
 [![CI](https://github.com/Ensembl/ensembl-py/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Ensembl/ensembl-py/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/pypi/v/ensembl-py)](https:pypi.org/project/ensembl-py)
+[![Release](https://img.shields.io/pypi/v/ensembl-py)](https://pypi.org/project/ensembl-py)
 
 Centralise generic Python code use across all other project within Ensembl, more particularly database access layers and ORMs, reusable eHive components, etc.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ docstring-code-format = true
 
 [tool.mypy]
 mypy_path = "src/python/ensembl"
+disallow_untyped_defs = true
 explicit_package_bases = true
 ignore_missing_imports = true
 show_error_codes = true

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -1997,7 +1997,7 @@ t_operon_transcript_gene = Table(
 @compiles(SET, "sqlite")
 def compile_set_sqlite(
     type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
-    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
     **kw: Any,  # pylint: disable=unused-argument
 ) -> str:
     """Cast MySQL SET to SQLite TEXT."""
@@ -2007,7 +2007,7 @@ def compile_set_sqlite(
 @compiles(TINYTEXT, "sqlite")
 def compile_tinytext_sqlite(
     type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
-    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
     **kw: Any,  # pylint: disable=unused-argument
 ) -> str:
     """Cast MySQL TINYTEXT to SQLite TEXT."""
@@ -2017,7 +2017,7 @@ def compile_tinytext_sqlite(
 @compiles(MEDIUMTEXT, "sqlite")
 def compile_mediumtext_sqlite(
     type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
-    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
     **kw: Any,  # pylint: disable=unused-argument
 ) -> str:
     """Cast MySQL MEDIUMTEXT to SQLite TEXT."""
@@ -2027,7 +2027,7 @@ def compile_mediumtext_sqlite(
 @compiles(LONGTEXT, "sqlite")
 def compile_longtext_sqlite(
     type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
-    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
     **kw: Any,  # pylint: disable=unused-argument
 ) -> str:
     """Cast MySQL LONGTEXT to SQLite TEXT."""
@@ -2037,7 +2037,7 @@ def compile_longtext_sqlite(
 @compiles(TINYINT, "sqlite")
 def compile_tinyint_sqlite(
     type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
-    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
     **kw: Any,  # pylint: disable=unused-argument
 ) -> str:
     """Cast MySQL TINYINT to SQLite INT."""

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -31,7 +31,9 @@
 #     are actually reserved (e.g. type, map, id) please help changing them into
 #     meaningful ones
 
+from typing import Any
 
+import sqlalchemy
 from sqlalchemy import (
     Column,
     DECIMAL,
@@ -1993,30 +1995,50 @@ t_operon_transcript_gene = Table(
 
 
 @compiles(SET, "sqlite")
-def compile_set_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_set_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL SET to SQLite TEXT."""
     return "TEXT"
 
 
 @compiles(TINYTEXT, "sqlite")
-def compile_tinytext_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_tinytext_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL TINYTEXT to SQLite TEXT."""
     return "TEXT"
 
 
 @compiles(MEDIUMTEXT, "sqlite")
-def compile_mediumtext_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_mediumtext_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL MEDIUMTEXT to SQLite TEXT."""
     return "TEXT"
 
 
 @compiles(LONGTEXT, "sqlite")
-def compile_longtext_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_longtext_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL LONGTEXT to SQLite TEXT."""
     return "TEXT"
 
 
 @compiles(TINYINT, "sqlite")
-def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_tinyint_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,   # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL TINYINT to SQLite INT."""
     return "INT"


### PR DESCRIPTION
Following the same idea as https://github.com/Ensembl/ensembl-utils/pull/23