### PR TITLE
Cast DOUBLE to NUMBER

### DIFF
--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -2024,6 +2024,10 @@ def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-arg
 
 
 @compiles(DOUBLE, "sqlite")
-def compile_double_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_double_sqlite(
+    type_: sqlalchemy.sql.expression.ColumnClause,  # pylint: disable=unused-argument
+    compiler: sqlalchemy.engine.interfaces.Compiled,  # pylint: disable=unused-argument
+    **kw: Any,  # pylint: disable=unused-argument
+) -> str:
     """Cast MySQL DOUBLE to SQLite NUMBER."""
     return "NUMBER"

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -2024,6 +2024,6 @@ def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-arg
 
 
 @compiles(DOUBLE, "sqlite")
-def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+def compile_double_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
     """Cast MySQL DOUBLE to SQLite NUMBER."""
     return "NUMBER"

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -47,6 +47,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.mysql import (
     BIGINT,
+    DOUBLE,
     INTEGER,
     LONGTEXT,
     MEDIUMTEXT,
@@ -2020,3 +2021,9 @@ def compile_longtext_sqlite(type_, compiler, **kw):  # pylint: disable=unused-ar
 def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
     """Cast MySQL TINYINT to SQLite INT."""
     return "INT"
+
+
+@compiles(DOUBLE, "sqlite")
+def compile_tinyint_sqlite(type_, compiler, **kw):  # pylint: disable=unused-argument
+    """Cast MySQL DOUBLE to SQLite NUMBER."""
+    return "NUMBER"


### PR DESCRIPTION
Pytest fails without casting Mysql DOUBLE to SQLite NUMBER.