### PR TITLE
Remove id key + add actual composite primary_key

### DIFF
--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -43,6 +43,7 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.dialects.mysql import (
@@ -1677,19 +1678,22 @@ class SeqRegionAttrib(Base):
         Index("region_attrib_value_idx", "value", mysql_length=10),
     )
 
-    seq_region_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     seq_region_id: Column = Column(
         ForeignKey("seq_region.seq_region_id"),
         nullable=False,
         index=True,
         server_default=text("'0'"),
+        primary_key=True,
     )
     attrib_type_id: Column = Column(
         ForeignKey("attrib_type.attrib_type_id"),
         nullable=False,
         server_default=text("'0'"),
+        primary_key=True,
     )
-    value: Column = Column(Text, nullable=False)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
+
+    UniqueConstraint("seq_region_id", "attrib_type_id", "value", name="region_attribx")
     seq_region = relationship("SeqRegion", back_populates="seq_region_attrib")
     attrib_type = relationship("AttribType", back_populates="seq_region_attrib")
 


### PR DESCRIPTION
- Fix a bug where the ORM defined in ensembl-py contained a key not present in the Ensembl core SQL schema: `seq_region_attrib_id`
- Set value to a String(500) for indexing
- Redefine the primary key as a composite of its fields (seq_region_id, attrib_type_id, value)
- Add unique key constraint like in the Ensembl core schema