### PR TITLE
Script to test ORM vs core + fixes

### DIFF
--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -200,7 +200,7 @@ class DNAAlignFeatureAttrib(Base):
         INTEGER(10), ForeignKey("dna_align_feature.dna_align_feature_id"), nullable=False, index=True, primary_key=True
     )
     attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 
 class ExternalDb(Base):
@@ -416,7 +416,7 @@ class RNAproductAttrib(Base):
     )
     rnaproduct_id: Column = Column(ForeignKey("rnaproduct.rnaproduct_id"), nullable=False, index=True, primary_key=True)
     attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 
 class RnaproductType(Base):
@@ -665,7 +665,7 @@ class GeneAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 class MarkerMapLocation(Base):
     __tablename__ = "marker_map_location"
@@ -875,7 +875,7 @@ class TranscriptAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 
 class TranscriptSupportingFeature(Base):
@@ -930,7 +930,7 @@ class TranslationAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 
 class UnmappedObject(Base):
@@ -1694,7 +1694,7 @@ class SeqRegionAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
     UniqueConstraint("seq_region_id", "attrib_type_id", "value", name="region_attribx")
     seq_region = relationship("SeqRegion", back_populates="seq_region_attrib")
@@ -1865,7 +1865,7 @@ class MiscAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(Text, nullable=False, primary_key=True)
+    value: Column = Column(String(500), nullable=False, primary_key=True)
 
 
 class OntologyXref(Base):

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -196,12 +196,11 @@ class DNAAlignFeatureAttrib(Base):
         Index("ditag_value_idx", "value", mysql_length=10),
     )
 
-    dna_align_feature_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     dna_align_feature_id: Column = Column(
-        INTEGER(10), ForeignKey("dna_align_feature.dna_align_feature_id"), nullable=False, index=True
+        INTEGER(10), ForeignKey("dna_align_feature.dna_align_feature_id"), nullable=False, index=True, primary_key=True
     )
-    attrib_type_id: Column = Column(SMALLINT(5), nullable=False)
-    value: Column = Column(Text, nullable=False)
+    attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 
 class ExternalDb(Base):
@@ -415,10 +414,9 @@ class RNAproductAttrib(Base):
         Index("rnaproduct_type_val_idx", "attrib_type_id", "value", mysql_length={"value": 10}),
         Index("rnaproduct_value_idx", "value", mysql_length=10),
     )
-    rnaproduct_attrib_id: Column = Column(INTEGER(10), primary_key=True)
-    rnaproduct_id: Column = Column(ForeignKey("rnaproduct.rnaproduct_id"), nullable=False, index=True)
-    attrib_type_id: Column = Column(SMALLINT(5), nullable=False)
-    value: Column = Column(Text, nullable=False)
+    rnaproduct_id: Column = Column(ForeignKey("rnaproduct.rnaproduct_id"), nullable=False, index=True, primary_key=True)
+    attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 
 class RnaproductType(Base):
@@ -652,22 +650,22 @@ class GeneAttrib(Base):
         Index("gene_attrib_value_idx", "value", mysql_length=10),
     )
 
-    gene_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     gene_id: Column = Column(
         INTEGER(10),
         ForeignKey("gene.gene_id"),
         nullable=False,
         index=True,
         server_default=text("'0'"),
+        primary_key=True,
     )
     attrib_type_id: Column = Column(
         SMALLINT(5),
         ForeignKey("attrib_type.attrib_type_id"),
         nullable=False,
         server_default=text("'0'"),
+        primary_key=True,
     )
-    value: Column = Column(Text, nullable=False)
-
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 class MarkerMapLocation(Base):
     __tablename__ = "marker_map_location"
@@ -862,21 +860,22 @@ class TranscriptAttrib(Base):
         Index("transcript_attrib_value_idx", "value", mysql_length=10),
     )
 
-    transcript_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     transcript_id: Column = Column(
         INTEGER(10),
         ForeignKey("transcript.transcript_id"),
         nullable=False,
         index=True,
         server_default=text("'0'"),
+        primary_key=True,
     )
     attrib_type_id: Column = Column(
         SMALLINT(5),
         ForeignKey("attrib_type.attrib_type_id"),
         nullable=False,
         server_default=text("'0'"),
+        primary_key=True,
     )
-    value: Column = Column(Text, nullable=False)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 
 class TranscriptSupportingFeature(Base):
@@ -904,7 +903,7 @@ class TranscriptSupportingFeature(Base):
 
 
 class TranslationAttrib(Base):
-    __tablename__ = ("translation_attrib",)
+    __tablename__ = "translation_attrib"
     __table_args__ = (
         Index("translation_attrib_type_val_idx", "attrib_type_id", "value", mysql_length={"value": 10}),
         Index(
@@ -918,19 +917,20 @@ class TranslationAttrib(Base):
         Index("translation_attrib_value_idx", "value", mysql_length=10),
     )
 
-    translation_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     translation_id: Column = Column(
         ForeignKey("translation.translation_id"),
         nullable=False,
         index=True,
         server_default=text("'0'"),
+        primary_key=True,
     )
     attrib_type_id: Column = Column(
         ForeignKey("attrib_type.attrib_type_id"),
         nullable=False,
         server_default=text("'0'"),
+        primary_key=True,
     )
-    value: Column = Column(Text, nullable=False)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 
 class UnmappedObject(Base):
@@ -1694,7 +1694,7 @@ class SeqRegionAttrib(Base):
         server_default=text("'0'"),
         primary_key=True,
     )
-    value: Column = Column(String(500), nullable=False, primary_key=True)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
     UniqueConstraint("seq_region_id", "attrib_type_id", "value", name="region_attribx")
     seq_region = relationship("SeqRegion", back_populates="seq_region_attrib")
@@ -1850,21 +1850,22 @@ class MiscAttrib(Base):
         Index("misc_attrib_value_idx", "value", mysql_length=10),
     )
 
-    misc_attrib_id: Column = Column(INTEGER(10), primary_key=True)
     misc_feature_id: Column = Column(
         INTEGER(10),
         ForeignKey("misc_feature.misc_feature_id"),
         nullable=False,
         index=True,
         server_default=text("'0'"),
+        primary_key=True,
     )
     attrib_type_id: Column = Column(
         SMALLINT(5),
         ForeignKey("attrib_type.attrib_type_id"),
         nullable=False,
         server_default=text("'0'"),
+        primary_key=True,
     )
-    value: Column = Column(Text, nullable=False)
+    value: Column = Column(Text, nullable=False, primary_key=True)
 
 
 class OntologyXref(Base):

--- a/src/python/ensembl/core/models.py
+++ b/src/python/ensembl/core/models.py
@@ -197,7 +197,11 @@ class DNAAlignFeatureAttrib(Base):
     )
 
     dna_align_feature_id: Column = Column(
-        INTEGER(10), ForeignKey("dna_align_feature.dna_align_feature_id"), nullable=False, index=True, primary_key=True
+        INTEGER(10),
+        ForeignKey("dna_align_feature.dna_align_feature_id"),
+        nullable=False,
+        index=True,
+        primary_key=True,
     )
     attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
     value: Column = Column(String(500), nullable=False, primary_key=True)
@@ -414,7 +418,9 @@ class RNAproductAttrib(Base):
         Index("rnaproduct_type_val_idx", "attrib_type_id", "value", mysql_length={"value": 10}),
         Index("rnaproduct_value_idx", "value", mysql_length=10),
     )
-    rnaproduct_id: Column = Column(ForeignKey("rnaproduct.rnaproduct_id"), nullable=False, index=True, primary_key=True)
+    rnaproduct_id: Column = Column(
+        ForeignKey("rnaproduct.rnaproduct_id"), nullable=False, index=True, primary_key=True
+    )
     attrib_type_id: Column = Column(SMALLINT(5), nullable=False, primary_key=True)
     value: Column = Column(String(500), nullable=False, primary_key=True)
 
@@ -666,6 +672,7 @@ class GeneAttrib(Base):
         primary_key=True,
     )
     value: Column = Column(String(500), nullable=False, primary_key=True)
+
 
 class MarkerMapLocation(Base):
     __tablename__ = "marker_map_location"

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -1,0 +1,55 @@
+# See the NOTICE file distributed with this work for additional information
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper script to check the current ensembl-py core model against a core created from Ensembl SQL."""
+
+from ensembl.utils.database import DBConnection
+from ensembl.utils.argparse import ArgumentParser
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound, MultipleResultsFound, OperationalError
+from sqlalchemy.orm import Session
+
+from ensembl.core.models import Base
+
+def check_tables(session: Session) -> None:
+    success = []
+    errors = []
+    for table_name, table in Base.metadata.tables.items():
+        stmt = select(table)
+        try:
+            session.execute(stmt).one()
+            success.append(table_name)
+        except (NoResultFound, MultipleResultsFound):
+            pass
+        except OperationalError as err:
+            # Show the problematic query and continue
+            print(f"{table_name}: {err}")
+            errors.append(table_name)
+    
+    print(f"{len(success)} tables successfully queried with the ORM")
+    print(f"{len(errors)} tables failed to be queried with the ORM: {errors}")
+
+def main() -> None:
+    """Main script entry-point."""
+    parser = ArgumentParser(
+        description="Fetch the genome metadata from a core database and print it in JSON format."
+    )
+    parser.add_argument("--url", required=True, type=str, help="MySQL URL to a core database to get tables data from")
+    args = parser.parse_args()
+
+    dbc = DBConnection(args.url, reflect=False)
+    with dbc.session_scope() as session:
+        check_tables(session)
+
+if __name__ == "__main__":
+    main()

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -65,12 +65,11 @@ def check_tables(session: Session, only_table: str = "") -> None:
 def main() -> None:
     """Main script entry-point."""
     parser = ArgumentParser(description=__doc__)
-    parser.add_server_arguments(database=True, help="Ensembl MySQL core database")
+    parser.add_server_arguments(include_database=True, help="Ensembl MySQL core database")
     parser.add_argument("--table", type=str, help="Test this one table only")
     parser.add_log_arguments(add_log_file=True)
     args = parser.parse_args()
     init_logging_with_args(args)
-
     dbc = DBConnection(args.url, reflect=False)
     with dbc.session_scope() as session:
         check_tables(session, only_table=args.table)

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -65,9 +65,7 @@ def check_tables(session: Session, only_table: str = "") -> None:
 def main() -> None:
     """Main script entry-point."""
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--url", required=True, type=str, help="MySQL URL to a core database to get tables data from"
-    )
+    parser.add_server_arguments(database=True, help="Ensembl MySQL core database")
     parser.add_argument("--table", type=str, help="Test this one table only")
     parser.add_log_arguments(add_log_file=True)
     args = parser.parse_args()

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Session
 
 from ensembl.core.models import Base
 
+
 def check_tables(session: Session, only_table: str = "") -> None:
     success = []
     errors = []
@@ -49,19 +50,20 @@ def check_tables(session: Session, only_table: str = "") -> None:
             # Show the problematic query and continue
             logging.warning(f"{table_name}: {err}")
             errors.append(table_name)
-    
+
     logging.info(f"{len(success)} tables successfully queried with the ORM")
     if errors:
         logging.warning(f"{len(errors)} tables failed to be queried with the ORM: {", ".join(errors)}")
     else:
         logging.info("No errors found")
 
+
 def main() -> None:
     """Main script entry-point."""
-    parser = ArgumentParser(
-        description=__doc__
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--url", required=True, type=str, help="MySQL URL to a core database to get tables data from"
     )
-    parser.add_argument("--url", required=True, type=str, help="MySQL URL to a core database to get tables data from")
     parser.add_argument("--table", type=str, help="Test this one table only")
     parser.add_log_arguments(add_log_file=True)
     args = parser.parse_args()
@@ -70,6 +72,7 @@ def main() -> None:
     dbc = DBConnection(args.url, reflect=False)
     with dbc.session_scope() as session:
         check_tables(session, only_table=args.table)
+
 
 if __name__ == "__main__":
     main()

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Check the current ensembl-py core model against a core created from Ensembl SQL.
-This script gets one row for each table in the ORM to check that SQLalchemy can correctly query the table.
-If not, it will show the OperationalError exception to explain what is wrong in the ORM.
+This script gets one row for each table in the ORM to check that SQLAlchemy can correctly query the table.
+If not, it will show the `OperationalError` exception to explain what is wrong in the ORM.
 
-Use this script this check the ORM and fix it.
+Use this script to check the ORM (and fix it if needed).
 """
 
 import logging

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -57,7 +57,7 @@ def check_tables(session: Session, only_table: str = "") -> None:
 
     logging.info(f"{len(success)} tables successfully queried with the ORM")
     if errors:
-        logging.warning(f"{len(errors)} tables failed to be queried with the ORM: {", ".join(errors)}")
+        logging.warning(f"{len(errors)} tables failed to be queried with the ORM: {', '.join(errors)}")
     else:
         logging.info("No errors found")
 

--- a/src/python/tests/core/compare_core_model.py
+++ b/src/python/tests/core/compare_core_model.py
@@ -20,6 +20,7 @@ Use this script this check the ORM and fix it.
 
 import logging
 
+from ensembl.core.models import Base
 from ensembl.utils.database import DBConnection
 from ensembl.utils.argparse import ArgumentParser
 from ensembl.utils.logging import init_logging_with_args
@@ -27,10 +28,14 @@ from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound, MultipleResultsFound, OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
-from ensembl.core.models import Base
-
 
 def check_tables(session: Session, only_table: str = "") -> None:
+    """Load data from a core using the ORM to check for any discrepancies in the definitions.
+
+    Args:
+        session: SQLAlchemy session.
+        only_table: Only check this one table instead of all of the tables defined in the ORM.
+    """
     success = []
     errors = []
     for table_name, table in Base.metadata.tables.items():
@@ -45,7 +50,6 @@ def check_tables(session: Session, only_table: str = "") -> None:
             success.append(table_name)
         except (NoResultFound, MultipleResultsFound):
             success.append(table_name)
-            pass
         except (OperationalError, ProgrammingError) as err:
             # Show the problematic query and continue
             logging.warning(f"{table_name}: {err}")


### PR DESCRIPTION
- Create a simple test script (to run manually) to test load all the tables defined in the ORM from a real core database, to flag any that fail to load
- Fix a few table definitions by removing an extra primary key in the *_attrib tables, and replacing them with a primary_key parameter on the columns the core schema use as unique
- NB: I also had to fix the string length to a definite value String(500), because SQLAlchemy needs that to create a primary key constraint in MySQL. This works now, but it might be problematic if we want to use the ORM to load very long attribs into a database. The best way to handle this really would be to alter the core SQL schema to have an explicit primary key as a simple autoincremented row ID.
