### PR TITLE
Set checksum_xref engine to MyISAM

### DIFF
--- a/src/python/ensembl/xrefs/xref_source_db_model.py
+++ b/src/python/ensembl/xrefs/xref_source_db_model.py
@@ -25,7 +25,7 @@ Base = declarative_base()
 
 class ChecksumXref(Base):
     __tablename__ = "checksum_xref"
-    __table_args__ = (Index("checksum_idx", "checksum", mysql_length=10),)
+    __table_args__ = (Index("checksum_idx", "checksum", mysql_length=10), {"mysql_engine": "MyISAM"})
 
     checksum_xref_id: Column = Column(INTEGER, primary_key=True, autoincrement=True)
     source_id: Column = Column(INTEGER, nullable=False)


### PR DESCRIPTION
Because of errors being faced when using 'LOAD DATA INFILE', we need to set the engine for the checksum table to MyISAM which helps reduce the probability of these errors. Will be revisiting this issue on a later date.