### PR TITLE
BugFix: make PR instead of attempting to do a commit to a protected branch

### DIFF
--- a/.github/workflows/notice.yml
+++ b/.github/workflows/notice.yml
@@ -23,6 +23,11 @@ jobs:
   notice_update:
     name: Update NOTICE copyright year
     runs-on: ubuntu-latest
+    env:
+      branch_name: bau/notice-update
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,5 +38,12 @@ jobs:
 
       - uses: EndBug/add-and-commit@v9
         with:
+          new_branch: ${{ env.branch_name }}
           add: 'NOTICE'
           message: 'Update NOTICE copyright year'
+
+      - name: Create pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create -B main -H $branch_name --title 'Update NOTICE copyright year' --body 'Created by GitHub action'


### PR DESCRIPTION
For the automatic NOTICE copyright update GitHub workflow. Tested in `ensembl-utils` repository.