### PR TITLE
Fetch LCA in method Taxonomy.last_common_ancestor

### DIFF
--- a/src/python/ensembl/ncbi_taxonomy/api/utils.py
+++ b/src/python/ensembl/ncbi_taxonomy/api/utils.py
@@ -251,4 +251,4 @@ class Taxonomy:
             ``taxon_id_2`` do not exist or have no common ancestors
         """
         common_ancestors = cls.all_common_ancestors(session, taxon_id_1, taxon_id_2)
-        return common_ancestors[0]
+        return common_ancestors[-1]


### PR DESCRIPTION
Currently, the output of the following snippet based on the Taxonomy API utilities usage example...
```python
dbc = DBConnection('mysql://anonymous@ensembldb.ensembl.org:3306/ncbi_taxonomy_114')

with dbc.session_scope() as session:
    dog_node = Taxonomy.fetch_taxon_by_species_name(session, 'canis_lupus_familiaris')
    mouse_node = Taxonomy.fetch_taxon_by_species_name(session, 'mus_musculus')
    common_anc = Taxonomy.last_common_ancestor(session, dog_node.taxon_id, mouse_node.taxon_id)
    print(f"LCA of dog and mouse has name '{common_anc.name}' and taxon_id {common_anc.taxon_id}")
```

...results in output:
```
LCA of dog and mouse has name 'all' and taxon_id 1
```

This PR would change the result of this call to `Taxonomy.last_common_ancestor` to be the LCA of the dog and mouse taxa:
```
LCA of dog and mouse has name 'Boreoeutheria' and taxon_id 1437010
```